### PR TITLE
Several new experimental features:

### DIFF
--- a/osx-dictionary.el
+++ b/osx-dictionary.el
@@ -188,7 +188,7 @@ Turning on Text mode runs the normal hook `osx-dictionary-mode-hook'."
 
 (defun osx-dictionary--search (word)
   "Search WORD."
-  (if (symbol-value 'osx-dictionary-search-log-file) 
+  (if (symbol-value 'osx-dictionary-search-log-file)
       (append-to-file
        (concat word "\n") nil
        (symbol-value 'osx-dictionary-search-log-file)))
@@ -196,9 +196,7 @@ Turning on Text mode runs the normal hook `osx-dictionary-mode-hook'."
          (concat
           (osx-dictionary-cli-find-or-recompile)
           " lookup "
-          (if (symbol-value 'osx-dictionary-dictionary-choice)
-              (symbol-value 'osx-dictionary-dictionary-choice)
-            "")
+          (or (symbol-value 'osx-dictionary-dictionary-choice) "")
           " "
           (shell-quote-argument word))))
     (progn

--- a/osx-dictionary.m
+++ b/osx-dictionary.m
@@ -90,7 +90,7 @@ NSString* suggest(char* w) {
 }
 
 int main(int argc, char *argv[]) {
-  
+
   NSString* result;
   char* rawInput;
   int arglen;
@@ -108,13 +108,12 @@ int main(int argc, char *argv[]) {
       return 0;
     } else {
       for (NSObject *d in s_dicts) {
-        NSString *sn = (__bridge NSString*)DCSDictionaryGetShortName((__bridge DCSDictionaryRef)d);        
+        NSString *sn = (__bridge NSString*)DCSDictionaryGetShortName((__bridge DCSDictionaryRef)d);
         [s_names setValue:d forKey:sn];
-        //[s_names setValue:sn forKey:[NSString stringWithFormat:@"%p",d]];
       }
     }
   }
-  
+
   if ([command isEqualToString:@"lookup"]) {
     if (argc == 4) {
       rawInput = argv[3];
@@ -133,11 +132,8 @@ int main(int argc, char *argv[]) {
       NSString* subStr = [inputStr substringWithRange:NSMakeRange(substringRange.location, substringRange.length)];
       NSArray* records = (NSArray*)DCSCopyRecordsForSearchString((__bridge DCSDictionaryRef)d, (__bridge CFStringRef)subStr, 0, 0);
       NSString* defStr = @"";
-      if (records) {      
-        /*defStr = [defStr stringByAppendingString:
-          [NSString stringWithFormat:@"[%@]\n", [s_names objectForKey:[NSString stringWithFormat:@"%p",d]]]];*/
+      if (records) {
         for (NSObject* r in records) {
-          // DCSRecordCopyData doesn't play with with the big boy dicts
           //CFStringRef data = DCSRecordGetTitle((__bridge CFTypeRef) r);
           CFStringRef data = DCSRecordGetRawHeadword((__bridge CFTypeRef) r);
           //CFStringRef data = DCSRecordGetHeadword((__bridge CFTypeRef) r);
@@ -145,7 +141,7 @@ int main(int argc, char *argv[]) {
             NSString* recordDef = (NSString*)DCSCopyTextDefinition((__bridge DCSDictionaryRef)d,
                                                                    data,
                                                                    CFRangeMake(0,CFStringGetLength(data)));
-            defStr = [defStr stringByAppendingString:[NSString stringWithFormat:@"%@\n\n", recordDef]];                       
+            defStr = [defStr stringByAppendingString:[NSString stringWithFormat:@"%@\n\n", recordDef]];
           }
         }
       }
@@ -157,17 +153,6 @@ int main(int argc, char *argv[]) {
       result = dictionary(rawInput);
     }
   }
-
-  /*
-
-  // send to dict look up
-
-  for (NSObject *d in s_dicts) {
-    CFRange substringRange = DCSGetTermRangeInString((__bridge DCSDictionaryRef)d, (__bridge CFStringRef)inputStr, 0);
-
-    
-
-    }*/
 
   if (result == nil) {
     int i, l;


### PR DESCRIPTION
* The ability to explicitly choose which dictionary to use by setting 'osx-dictionary-dictionary-choice.
* The ability to log all items a user has searched for.

I wouldn't recommend actually merging yet as I'm still developing, testing and cleaning up the code for these features, but, since you appear to be actively working on this plugin, I wanted to see what you thought.  

Dictionary choice relies on an undocumented API call so it could be unstable, but it is something that I very much need since I work often between, for example, French and English and "porter" appears in both dictionaries. That said, I understand if you don't want to include this in the distributed version of the library since, again, it includes undocumented API calls. 

The logging, however, is something you list in your TODO, so I of course assume that it is a feature you are more apt to accept. Note that my implementation is very rudimentary and I will be continuing to expand in the next few days---please let me know if there's anything that would be especially useful for you, here. My plan is to further develop or incorporate a flash-card mode atop this output to help with language learning.