### PR TITLE
whitespace cleaned up before presenting Dictionary.app results

### DIFF
--- a/osx-dictionary.el
+++ b/osx-dictionary.el
@@ -206,6 +206,7 @@ Turning on Text mode runs the normal hook `osx-dictionary-mode-hook'."
           (progress-reporter-done progress-reporter))
         (osx-dictionary--goto-dictionary)
         (goto-char (point-min))
+        (whitespace-cleanup)
         (setq buffer-read-only t))
     (message "Nothing to look up")))
 


### PR DESCRIPTION
I have `whitespace-mode` always active. Then, when searching for a word's definition using `osx-dictionary`, I get pinky boxes where whitespace is. They make it difficult to read the contents of `*osx-dictionary*` buffer (as shown in the attached screenshot).

I propose to clean up white spaces before displaying the results to `*osx-dictionary*`.

![screen shot 2016-12-07 at 13 23 36](https://cloud.githubusercontent.com/assets/1950853/20967707/29ad9658-bc81-11e6-8b2a-e7adb2589687.png)