### PR TITLE
visual-line-mode set before presenting Dictionary.app results

### DIFF
--- a/osx-dictionary.el
+++ b/osx-dictionary.el
@@ -206,6 +206,7 @@ Turning on Text mode runs the normal hook `osx-dictionary-mode-hook'."
           (progress-reporter-done progress-reporter))
         (osx-dictionary--goto-dictionary)
         (goto-char (point-min))
+        (visual-line-mode)
         (setq buffer-read-only t))
     (message "Nothing to look up")))
 


### PR DESCRIPTION
Line wrapping does not look so great when running Emacs in the terminal, as shown below.

![screen shot 2016-12-07 at 13 34 34](https://cloud.githubusercontent.com/assets/1950853/20967961/2adf6302-bc82-11e6-9c21-6ca87423002d.png)

I propose to activate `visual-line-mode` before presenting the contents of the `*osx-dictionary*`.