### PR TITLE
alias osx-dictionary-search-word-at-point added to agree with other p…

### DIFF
--- a/osx-dictionary.el
+++ b/osx-dictionary.el
@@ -226,6 +226,8 @@ Turning on Text mode runs the normal hook `osx-dictionary-mode-hook'."
   (let ((word (osx-dictionary--region-or-word)))
     (osx-dictionary--view-result word)))
 
+(defalias 'osx-dictionary-search-word-at-point 'osx-dictionary-search-pointer)
+
 ;;;###autoload
 (defun osx-dictionary-get-all-dictionaries ()
   "Get all dictionaries as a list."


### PR DESCRIPTION
…ackages APIs

Other packages use the suffix `at-point` when working with the `thing-at-point`.

![screen shot 2016-12-07 at 13 38 31](https://cloud.githubusercontent.com/assets/1950853/20968061/c64c0ee4-bc82-11e6-9650-4c1221fb29aa.png)

It would be nice if `osx-dictionary` conformed to the `-at-point` pattern.