### PR TITLE
Promote the argc guard upfront

### DIFF
--- a/osx-dictionary.m
+++ b/osx-dictionary.m
@@ -62,8 +62,9 @@ NSString* suggest(char* w) {
 }
 
 int main(int argc, char *argv[]) {
+  if (argc < 2) return 0;
   int arglen = strlen(argv[1]);
-  if (argc < 2 || arglen == 0) return 0;
+  if (arglen == 0) return 0;
   NSString* result = dictionary(argv[1]);
   if (result == nil) {
     int i, l;


### PR DESCRIPTION
Otherwise `strlen(argv[1])` would simply just be undefined (Segfault 11)