### PR TITLE
Capture only stdout and discard stderr

### DIFF
--- a/osx-dictionary.el
+++ b/osx-dictionary.el
@@ -177,7 +177,7 @@ Turning on Text mode runs the normal hook `osx-dictionary-mode-hook'."
      (expand-file-name osx-dictionary-search-log-file)))
   ;; Search
   (shell-command-to-string
-   (format "%s %s"
+   (format "%s %s 2>/dev/null"
            (shell-quote-argument (osx-dictionary-cli-find-or-recompile))
            (shell-quote-argument word))))
 


### PR DESCRIPTION
Similar fix was applied at https://github.com/itchyny/dictionary.vim with commit https://github.com/itchyny/dictionary.vim/commit/4f95609166e91ea71fe613e5041670a5fcee7a6e. 

Fixes #19.

Reasoning for using `... 2>/dev/null`:
- `shell-command-to-string` doesn't support separate stdout and stderr streams
- `shell-command` does support capturing separate streams but we anyway have to discard the stderr, so no point in capturing it