### PR TITLE
Handle middle dot (·) in word

### DIFF
--- a/osx-dictionary.el
+++ b/osx-dictionary.el
@@ -129,16 +129,17 @@ Turning on Text mode runs the normal hook `osx-dictionary-mode-hook'."
 (defun osx-dictionary-open-dictionary.app ()
   "Open current searched `word' in Dictionary.app."
   (interactive)
-  (save-excursion
-    (goto-char (point-min))
-    (shell-command (format "open dict://%s" (thing-at-point 'word)))))
+  (shell-command (format "open dict://%s" (osx-dictionary--get-current-word))))
 
 (defun osx-dictionary-read-word ()
   "Open current searched `word' in Dictionary.app."
   (interactive)
+  (shell-command (concat "say " (shell-quote-argument (osx-dictionary--get-current-word)))))
+
+(defun osx-dictionary--get-current-word ()
   (save-excursion
     (goto-char (point-min))
-    (shell-command (concat "say " (shell-quote-argument (thing-at-point 'word))))))
+    (thing-at-point 'word)))
 
 (defun osx-dictionary-quit ()
   "Quit osx-dictionary: reselect previously selected buffer."

--- a/osx-dictionary.el
+++ b/osx-dictionary.el
@@ -139,7 +139,7 @@ Turning on Text mode runs the normal hook `osx-dictionary-mode-hook'."
 (defun osx-dictionary--get-current-word ()
   (save-excursion
     (goto-char (point-min))
-    (thing-at-point 'word)))
+    (string-replace "·" "" (thing-at-point 'word))))
 
 (defun osx-dictionary-quit ()
   "Quit osx-dictionary: reselect previously selected buffer."


### PR DESCRIPTION
From Catalina (if I remember correctly), osx dictionary cli returns middle dot in the word:

```
re·place | rəˈplās | verb [with object]
1 take the place of: Ian's smile was replaced by a frown.
  • provide or find a substitute for (something that is broken, old, or inoperative): the light bulb needs replacing.
  • fill the role of (someone or something) with a substitute: the government dismissed 3,000 of its customs inspectors, replacing them with new recruits.
2 put (something) back in a previous place or position: he drained his glass and replaced it on the bar.
DERIVATIVES replacer noun
```

So when we call `say "re·place"`, it reads `re-dot-place`, which is not we want.

This PR fixes this issue by removing this `·`
