### PR TITLE
Update osx-dictionary.m

### DIFF
--- a/osx-dictionary.m
+++ b/osx-dictionary.m
@@ -6,7 +6,6 @@
 // Use: osx-dictionary-cli WORD
 // ============================================================================
 
-#import <Foundation/Foundation.h>
 #import <CoreServices/CoreServices.h>
 
 #define isnum(x)\


### PR DESCRIPTION
Import foundation.h cause compilation error. Turns out it is not necessary.

Shall fix #32 #22