### PR TITLE
Correct docstring for osx-dictionary-read-word

### DIFF
--- a/osx-dictionary.el
+++ b/osx-dictionary.el
@@ -143,7 +143,7 @@ Turning on Text mode runs the normal hook `osx-dictionary-mode-hook'."
   (shell-command (format "open dict://%s" (osx-dictionary--get-current-word))))
 
 (defun osx-dictionary-read-word ()
-  "Open current searched `word' in Dictionary.app."
+  "Read current searched `word' using text-to-speech service."
   (interactive)
   (shell-command (concat "say " (shell-quote-argument (osx-dictionary--get-current-word)))))
 


### PR DESCRIPTION
The docstring for the `osx-dictionary-read-word` command isn't right. It's the same as for `osx-dictionary-open-word`, so I suppose this was unintended left-over from copy + paste.

This PR updates the docstring to reflect what the command is actually for.