### PR TITLE
Add required header for compiling `osx-dictionary-cli`, #36

### DIFF
--- a/osx-dictionary.m
+++ b/osx-dictionary.m
@@ -6,6 +6,7 @@
 // Use: osx-dictionary-cli WORD
 // ============================================================================
 
+#import <Foundation/Foundation.h>
 #import <CoreServices/CoreServices.h>
 
 #define isnum(x)\


### PR DESCRIPTION
As title.